### PR TITLE
Allow providing an external loop for scheduler

### DIFF
--- a/aiojobs/__init__.py
+++ b/aiojobs/__init__.py
@@ -4,13 +4,17 @@ import asyncio
 from ._scheduler import Scheduler
 
 
-async def create_scheduler(*, close_timeout=0.1, limit=100,
-                           exception_handler=None):
+async def create_scheduler(*,
+                           close_timeout=0.1,
+                           limit=100,
+                           exception_handler=None,
+                           loop=None):
     if exception_handler is not None and not callable(exception_handler):
         raise TypeError('A callable object or None is expected, '
                         'got {!r}'.format(exception_handler))
-    loop = asyncio.get_event_loop()
-    return Scheduler(loop=loop, close_timeout=close_timeout,
+    loop = loop or asyncio.get_event_loop()
+    return Scheduler(loop=loop,
+                     close_timeout=close_timeout,
                      limit=limit,
                      exception_handler=exception_handler)
 


### PR DESCRIPTION
Currently scheduler is created on the loop from asyncio.get_event_loop(), without an ability to customize it.
This PR adds an ability to pass in an external loop.