### PR TITLE
Add Scheduler::spawn_nowait to spawn jobs synchronously

### DIFF
--- a/aiojobs/_scheduler.py
+++ b/aiojobs/_scheduler.py
@@ -64,21 +64,16 @@ class Scheduler(*bases):
     def closed(self):
         return self._closed
 
-    async def spawn(self, coro):
+    async def spawn(self, coro) -> Job:
         # The method is not a coroutine
         # but let's keep it async for sake of future changes
         # Migration from function to coroutine is a pain
-        if self._closed:
-            raise RuntimeError("Scheduling a new job after closing")
-        job = Job(coro, self, self._loop)
-        should_start = (self._limit is None or
-                        self.active_count < self._limit)
-        self._jobs.add(job)
-        if should_start:
-            job._start()
-        else:
-            self._pending.append(job)
-        return job
+        return self.spawn_nowait(coro)
+
+    def spawn_nowait(self, coro) -> Job:
+        """Synchronous version of `spawn`.
+        """
+        return self._spawn_nowait(coro)
 
     async def close(self):
         if self._closed:
@@ -107,6 +102,21 @@ class Scheduler(*bases):
     @property
     def exception_handler(self):
         return self._exception_handler
+
+    def _spawn_nowait(self, coro) -> Job:
+        """Common (synchronous) job-spawning code.
+        """
+        if self._closed:
+            raise RuntimeError("Scheduling a new job after closing")
+        job = Job(coro, self, self._loop)
+        should_start = (self._limit is None or
+                        self.active_count < self._limit)
+        self._jobs.add(job)
+        if should_start:
+            job._start()
+        else:
+            self._pending.append(job)
+        return job
 
     def _done(self, job):
         self._jobs.discard(job)

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -1,4 +1,5 @@
-pytest-aiohttp
-pytest-cov
-flake8
 -e .
+flake8
+pytest-aiohttp
+pytest-asyncio
+pytest-cov

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -19,6 +19,20 @@ async def test_spawn(scheduler, loop):
     assert job in scheduler
 
 
+async def test_spawn_nowait(scheduler, loop):
+    async def coro():
+        return 1
+    job = scheduler.spawn_nowait(coro())
+    ret = await job.wait()
+    assert ret == 1
+
+    assert job.closed
+
+    assert len(scheduler) == 0
+    assert list(scheduler) == []
+    assert job not in scheduler
+
+
 async def test_run_retval(scheduler, loop):
     async def coro():
         return 1


### PR DESCRIPTION
Per #13, this PR adds a method to spawn jobs from synchronous code. I borrowed the `_nowait` nomenclature from `asyncio.Queue` and its friends.