### PR TITLE
Add `pending_limit` into Scheduler (ref #19)

### DIFF
--- a/aiojobs/__init__.py
+++ b/aiojobs/__init__.py
@@ -4,14 +4,14 @@ import asyncio
 from ._scheduler import Scheduler
 
 
-async def create_scheduler(*, close_timeout=0.1, limit=100,
+async def create_scheduler(*, close_timeout=0.1, limit=100, pending_limit=100,
                            exception_handler=None):
     if exception_handler is not None and not callable(exception_handler):
         raise TypeError('A callable object or None is expected, '
                         'got {!r}'.format(exception_handler))
     loop = asyncio.get_event_loop()
     return Scheduler(loop=loop, close_timeout=close_timeout,
-                     limit=limit,
+                     limit=limit, pending_limit=pending_limit,
                      exception_handler=exception_handler)
 
 __all__ = ('create_scheduler',)

--- a/aiojobs/_scheduler.py
+++ b/aiojobs/_scheduler.py
@@ -10,7 +10,7 @@ except ImportError:  # pragma: no cover
     from collections.abc import Sized, Iterable, Container
     bases = Sized, Iterable, Container
 else:  # pragma: no cover
-    bases = (Collection, )
+    bases = (Collection,)
 
 
 class Scheduler(*bases):
@@ -81,10 +81,10 @@ class Scheduler(*bases):
         if self._closed:
             raise RuntimeError("Scheduling a new job after closing")
         job = Job(coro, self, self._loop)
-        should_start = (self._limit is None
-                        or self.active_count < self._limit)
-        should_wait = (self._pending_limit is not None
-                       and self.pending_count >= self._pending_limit)
+        should_start = (self._limit is None or 
+                        self.active_count < self._limit)
+        should_wait = (self._pending_limit is not None and 
+                       self.pending_count >= self._pending_limit)
         if not should_start and should_wait:
             waiter = self._loop.create_future()
             waiter._job = job

--- a/aiojobs/_scheduler.py
+++ b/aiojobs/_scheduler.py
@@ -81,9 +81,9 @@ class Scheduler(*bases):
         if self._closed:
             raise RuntimeError("Scheduling a new job after closing")
         job = Job(coro, self, self._loop)
-        should_start = (self._limit is None or 
+        should_start = (self._limit is None or
                         self.active_count < self._limit)
-        should_wait = (self._pending_limit is not None and 
+        should_wait = (self._pending_limit is not None and
                        self.pending_count >= self._pending_limit)
         if not should_start and should_wait:
             waiter = self._loop.create_future()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,10 @@ import pytest
 from aiojobs import create_scheduler
 from aiojobs._scheduler import Scheduler
 
-PARAMS = dict(close_timeout=1.0, limit=100, exception_handler=None)
+PARAMS = dict(close_timeout=1.0,
+              limit=100,
+              pending_limit=100,
+              exception_handler=None)
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR for #19 
- Add parameter `pending_limit` into `Scheduler`
  for control pending jobs size
- Add property `pending_limit` into `Scheduler`
- Add property `waiting_count` into `Scheduler`