### PR TITLE
Update the code example of atomic decorator

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -260,5 +260,5 @@ Helpers
           return web.Response()
 
       async def handler(request):
-          job = await spawn(request, coro(request))
+          job = await spawn(request, inner(request))
           return await job.wait()


### PR DESCRIPTION
The code example showing the code equivalent has two coroutines: inner and handler.
I think within `handler`, you meant to spawn `inner` instead of `coro`.
Or `inner` could be renamed to `coro`.

Anyway I replaced `coro` with `inner`.