### PR TITLE
Resolve scheduler from parent applications if nested app does not have a scheduler

### DIFF
--- a/aiojobs/aiohttp.py
+++ b/aiojobs/aiohttp.py
@@ -9,7 +9,7 @@ __all__ = ('setup', 'spawn', 'get_scheduler', 'get_scheduler_from_app',
 
 
 def get_scheduler(request):
-    scheduler = get_scheduler_from_app(request.app)
+    scheduler = get_scheduler_from_request(request)
     if scheduler is None:
         raise RuntimeError(
             "Call aiojobs.aiohttp.setup() on application initialization")
@@ -18,6 +18,10 @@ def get_scheduler(request):
 
 def get_scheduler_from_app(app):
     return app.get('AIOJOBS_SCHEDULER')
+
+
+def get_scheduler_from_request(request):
+    return request.config_dict.get('AIOJOBS_SCHEDULER')
 
 
 async def spawn(request, coro):

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -218,7 +218,8 @@ jobs.
 
 .. cofunction:: spawn(request, coro)
 
-   Spawn a new job using scheduler registered into ``request.app``.
+   Spawn a new job using scheduler registered into ``request.app``,
+   or a parent :attr:`aiohttp.web.Application`.
 
    * *request* -- :class:`aiohttp.web.Request` given from :term:`web-handler`
    * *coro* a coroutine to be executed inside a new job
@@ -232,7 +233,8 @@ Helpers
 
    Return a scheduler from request, raise :exc:`RuntimeError` if
    scheduler was not registered on application startup phase (see
-   :func:`setup`).
+   :func:`setup`). The scheduler will be resolved from the current
+   or any parent :attr:`aiohttp.web.Application`, if available.
 
 
 .. function:: get_scheduler_from_app(app)
@@ -240,6 +242,12 @@ Helpers
    Return a scheduler from aiohttp application or ``None`` if
    scheduler was not registered on application startup phase (see
    :func:`setup`).
+
+.. function:: get_scheduler_from_request(request)
+
+   Return a scheduler from aiohttp request or ``None`` if
+   scheduler was not registered on any application in the
+   hierarchy of parent applications (see :func:`setup`)
 
 .. decorator:: atomic
 

--- a/tests/test_aiohttp.py
+++ b/tests/test_aiohttp.py
@@ -3,7 +3,8 @@ import asyncio
 import pytest
 from aiohttp import web
 
-from aiojobs.aiohttp import atomic, get_scheduler, get_scheduler_from_app
+from aiojobs.aiohttp import (atomic, get_scheduler, get_scheduler_from_app,
+                             get_scheduler_from_request)
 from aiojobs.aiohttp import setup as aiojobs_setup
 from aiojobs.aiohttp import spawn
 
@@ -87,3 +88,40 @@ async def test_atomic_from_view(test_client):
 
     assert scheduler.active_count == 0
     assert scheduler.pending_count == 0
+
+
+async def test_nested_application(test_client):
+    app = web.Application()
+    aiojobs_setup(app)
+
+    app2 = web.Application()
+
+    class MyView(web.View):
+        async def get(self):
+            assert get_scheduler_from_request(self.request) ==\
+                get_scheduler_from_app(app)
+            return web.Response()
+
+    app2.router.add_route("*", "/", MyView)
+    app.add_subapp("/sub/", app2)
+
+    client = await test_client(app)
+    resp = await client.get("/sub/")
+    assert resp.status == 200
+
+
+async def test_nested_application_not_set(test_client):
+    app = web.Application()
+    app2 = web.Application()
+
+    class MyView(web.View):
+        async def get(self):
+            assert get_scheduler_from_request(self.request) is None
+            return web.Response()
+
+    app2.router.add_route("*", "/", MyView)
+    app.add_subapp("/sub/", app2)
+
+    client = await test_client(app)
+    resp = await client.get("/sub/")
+    assert resp.status == 200


### PR DESCRIPTION
Default resolution of the scheduler from a request to search the app hierarchy instead of only the current `web.Application`. I made this the default behavior under the assumption that the typical use-case will be a shared scheduler across an application at a parent level, but allowing the first resolved to be used in the cases nested applications have a separate scheduler.

Fixes #51 