### PR TITLE
Fix failed closed jobs

### DIFF
--- a/CHANGES/29.bugfix
+++ b/CHANGES/29.bugfix
@@ -1,0 +1,1 @@
+Fix AttributeError when calling wait() or close() on failed job.

--- a/aiojobs/_job.py
+++ b/aiojobs/_job.py
@@ -50,6 +50,8 @@ class Job:
             return await self._task
 
     async def wait(self, *, timeout=None):
+        if self._closed:
+            return
         self._explicit = True
         scheduler = self._scheduler
         try:
@@ -63,14 +65,14 @@ class Job:
             raise
 
     async def close(self, *, timeout=None):
+        if self._closed:
+            return
         self._explicit = True
         if timeout is None:
             timeout = self._scheduler.close_timeout
         await self._close(timeout)
 
     async def _close(self, timeout):
-        if self._closed:
-            return
         self._closed = True
         if self._task is None:
             # the task is closed immediately without actual execution

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -194,3 +194,37 @@ async def test_job_cancel_awaiting(make_scheduler, loop):
 
     assert not fut.cancelled()
     fut.set_result(None)
+
+
+async def test_job_wait_closed(make_scheduler):
+    scheduler = await make_scheduler(limit=1)
+    fut = asyncio.Future()
+
+    async def coro1():
+        raise RuntimeError()
+
+    async def coro2():
+        fut.set_result(None)
+
+    job = await scheduler.spawn(coro1())
+    await scheduler.spawn(coro2())
+
+    await fut
+    await job.wait()
+
+
+async def test_job_close_closed(make_scheduler):
+    scheduler = await make_scheduler(limit=1)
+    fut = asyncio.Future()
+
+    async def coro1():
+        raise RuntimeError()
+
+    async def coro2():
+        fut.set_result(None)
+
+    job = await scheduler.spawn(coro1())
+    await scheduler.spawn(coro2())
+
+    await fut
+    await job.close()


### PR DESCRIPTION
Fix AttributeError when calling wait() or close() on failed job. 

Issue: #29 

