### PR TITLE
Save spawned task result

### DIFF
--- a/aiojobs/_job.py
+++ b/aiojobs/_job.py
@@ -10,6 +10,7 @@ class Job:
     _closed = False
     _explicit = False
     _task = None
+    _result = None
 
     def __init__(self, coro, scheduler, loop):
         self._loop = loop
@@ -51,7 +52,7 @@ class Job:
 
     async def wait(self, *, timeout=None):
         if self._closed:
-            return
+            return self._result
         self._explicit = True
         scheduler = self._scheduler
         try:
@@ -114,6 +115,8 @@ class Job:
         scheduler._done(self)
         try:
             exc = task.exception()
+            if exc is None:
+                self._result = task.result()
         except asyncio.CancelledError:
             pass
         else:

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -94,6 +94,7 @@ async def test_job_wait_result(make_scheduler):
         return 1
 
     job = await scheduler.spawn(coro())
+    await asyncio.sleep(1)
     ret = await job.wait()
     assert ret == 1
     assert not handler.called
@@ -170,6 +171,7 @@ async def test_job_await_pending(make_scheduler, loop):
     job = await scheduler.spawn(coro2())
 
     loop.call_later(0.01, fut.set_result, None)
+    await asyncio.sleep(1)
     ret = await job.wait()
     assert ret == 1
 


### PR DESCRIPTION
If job is closed before `Job.wait()` was called the result of task is lost.