### PR TITLE
Add graceful shutdown (#48)

### DIFF
--- a/CHANGES/48.feature
+++ b/CHANGES/48.feature
@@ -1,0 +1,1 @@
+Add graceful shutdown

--- a/aiojobs/_job.py
+++ b/aiojobs/_job.py
@@ -59,7 +59,8 @@ class Job:
             self._report_timeout(exc, scheduler)
             raise
 
-    async def wait(self, *, timeout=None, graceful_timeout=None, explicit=True):
+    async def wait(self, *, timeout=None, graceful_timeout=None,
+                   explicit=True):
         if self._closed:
             return
         self._explicit = explicit
@@ -68,8 +69,9 @@ class Job:
             if self._explicit:
                 return await asyncio.shield(self._do_wait(timeout),
                                             loop=self._loop)
-            return await asyncio.shield(self._do_graceful_wait(timeout, graceful_timeout),
-                                        loop=self._loop)
+            return await asyncio.shield(
+                self._do_graceful_wait(timeout, graceful_timeout),
+                loop=self._loop)
         except asyncio.CancelledError:
             # Don't stop inner coroutine on explicit cancel
             raise

--- a/aiojobs/_scheduler.py
+++ b/aiojobs/_scheduler.py
@@ -113,8 +113,9 @@ class Scheduler(*bases):
             while not self._pending.empty():
                 job = self._pending.get_nowait()
                 job._start()
-            await asyncio.gather(*map(prepare_job, jobs),
-                                loop=self._loop, return_exceptions=True)
+            await asyncio.gather(
+                *map(prepare_job, jobs),
+                loop=self._loop, return_exceptions=True)
             self._jobs.clear()
         self._failed_tasks.put_nowait(None)
         await self._failed_task

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -133,6 +133,17 @@ async def test_join(make_scheduler, loop):
     assert not exc_handler.called
 
 
+async def test_join_on_closed(make_scheduler, loop):
+    exc_handler = mock.Mock()
+    scheduler = await make_scheduler(exception_handler=exc_handler)
+
+    assert not scheduler._closed
+    await scheduler.join()
+    assert scheduler._closed
+    await scheduler.join()
+    assert not exc_handler.called
+
+
 async def test_exception_on_join(make_scheduler, loop):
     exc_handler = mock.Mock()
     scheduler = await make_scheduler(exception_handler=exc_handler, limit=1)


### PR DESCRIPTION
## Что нового?
Добавлен функционал, о котором писали в проблеме #48.
Scheduler ожидает выполнения всех задач (active & pending) при завершении работы .

## Реализация.
_coroutine_ Scheduler.**join**(_timeout=1, graceful_timeout=1_)
- **timeout** (_int_) - определяет задержку, перед тем как в задаче будет возбуждено исключение asyncio.CancelledError. 
- **graceful_timeout** (_int_) - время, которое отведено задаче на завершение работы после возбуждения исключения.