### PR TITLE
Add await to spawn in docs

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -57,7 +57,7 @@ There is simple usage example::
 
    scheduler = await aiojobs.create_scheduler()
 
-   job = scheduler.spawn(f())
+   job = await scheduler.spawn(f())
 
    await scheduler.close()
 


### PR DESCRIPTION
Look like a mistake in documentation, but it can lead to unexpected result: `spawn` without `await` will return just coroutine, not the Job instance.