### PR TITLE
Allow zero-sized pending queue

### DIFF
--- a/CHANGES/152.feature
+++ b/CHANGES/152.feature
@@ -1,0 +1,1 @@
+Allow zero-sized (real zero, not infinite) pending queue

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -26,6 +26,7 @@ Instantiation
 
    * *pending_limit* is a limit for amount of jobs awaiting starting,
      ``10000`` by default. Use ``0`` for infinite pending queue size.
+     Use ``None`` to ignore pending queue at all
 
    * *exception_handler* is a callable with
      ``handler(scheduler, context)`` signature to log
@@ -70,7 +71,7 @@ Scheduler
 
    .. attribute:: pending_limit
 
-      A limit for *pending* queue size (``0`` for unlimited queue).
+      A limit for *pending* queue size (``0`` for unlimited queue, ``None`` to ignore queue).
 
       See :meth:`spawn` for details.
 
@@ -102,9 +103,9 @@ Scheduler
       if concurrency :attr:`limit` exceeded.
 
       If :attr:`pending_count` is greater than :attr:`pending_limit`
-      and the limit is *finite* (not ``0``) the method suspends
+      and the limit is *finite* (not ``0``) and not ``None`` the method suspends
       execution without scheduling a new job (adding it into pending
-      queue) until penging queue size will be reduced to have a free
+      queue) until pending queue size will be reduced to have a free
       slot.
 
       .. versionchanged:: 0.2

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -236,6 +236,22 @@ async def test_pending_limit(make_scheduler):
     assert s2.pending_limit == 2
 
 
+async def test_pending_limit_none(make_scheduler):
+    s = await make_scheduler(pending_limit=None)
+
+    async def coro(fut):
+        await fut
+
+    fut1 = asyncio.Future()
+    fut2 = asyncio.Future()
+
+    await s.spawn(coro(fut1))
+    assert s.pending_count == 0
+
+    await s.spawn(coro(fut2))
+    assert s.pending_count == 0
+
+
 async def test_pending_queue_infinite(make_scheduler):
     scheduler = await make_scheduler(limit=1)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Now `pending_limit=0` creates unlimited pending queue which is not fully correct. Now one can pass `pending_limit=None` to ignore pending queue at all

## Are there changes in behavior for the user?

No

## Related issue number

None

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
