### PR TITLE
Return task value when waiting on closed job.

### DIFF
--- a/aiojobs/_job.py
+++ b/aiojobs/_job.py
@@ -51,7 +51,7 @@ class Job:
 
     async def wait(self, *, timeout=None):
         if self._closed:
-            raise asyncio.CancelledError("Job already closed")
+            return await self._task
         self._explicit = True
         scheduler = self._scheduler
         try:

--- a/aiojobs/_job.py
+++ b/aiojobs/_job.py
@@ -51,7 +51,7 @@ class Job:
 
     async def wait(self, *, timeout=None):
         if self._closed:
-            return
+            raise asyncio.CancelledError("Job already closed")
         self._explicit = True
         scheduler = self._scheduler
         try:

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -257,6 +257,7 @@ async def test_job_await_explicit_close(scheduler) -> None:
     job = await scheduler.spawn(coro())
     assert not job._closed
 
+    # Ensure coro() task is started before close().
     await asyncio.sleep(0)
     await job.close()
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -212,7 +212,8 @@ async def test_job_wait_closed(make_scheduler):
     await scheduler.spawn(coro2())
 
     await fut
-    await job.wait()
+    with pytest.raises(RuntimeError):
+        await job.wait()
 
 
 async def test_job_close_closed(make_scheduler):

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -240,6 +240,9 @@ async def test_job_await_closed(scheduler) -> None:
     job = await scheduler.spawn(coro())
     assert not job._closed
 
+    # Let coro run.
+    await asyncio.sleep(0)
+    # Then let done callback run.
     await asyncio.sleep(0)
 
     assert job._closed

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -239,7 +239,7 @@ async def test_job_await_closed(scheduler) -> None:
 
     job = await scheduler.spawn(coro())
     assert not job._closed
-    
+
     await asyncio.sleep(0)
 
     assert job._closed
@@ -253,7 +253,7 @@ async def test_job_await_explicit_close(scheduler) -> None:
 
     job = await scheduler.spawn(coro())
     assert not job._closed
-    
+
     await asyncio.sleep(0)
     await job.close()
 


### PR DESCRIPTION
Returning `None` seems like a dangerous move, if something is expecting a different value. This also results in a bunch of typing errors when type checked with mypy.