### PR TITLE
Fix double call to exception handler.

### DIFF
--- a/aiojobs/_job.py
+++ b/aiojobs/_job.py
@@ -115,7 +115,6 @@ class Job(Generic[_T]):
         except Exception as exc:
             if self._explicit:
                 raise
-            self._report_exception(exc)
 
     def _start(self) -> None:
         assert self._task is None

--- a/aiojobs/_job.py
+++ b/aiojobs/_job.py
@@ -112,7 +112,7 @@ class Job(Generic[_T]):
             # there's no timeout. self._scheduler will now be None though.
             assert scheduler is not None
             scheduler.call_exception_handler(context)
-        except Exception as exc:
+        except Exception:
             if self._explicit:
                 raise
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -284,6 +284,6 @@ async def test_exception_handler_called_once(make_scheduler: _MakeScheduler) -> 
     async def coro() -> NoReturn:
         raise Exception()
 
-    job = await scheduler.spawn(coro())
+    await scheduler.spawn(coro())
     await scheduler.close()
     handler.assert_called_once()


### PR DESCRIPTION
Fixes #146.

The report exception call here seems unneeded, it will be called a moment later once the done callback is called.