### PR TITLE
Fix mypy run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ setup: .develop
 .PHONY: lint
 lint:
 	pre-commit run --all-files
-	mypy .
+	mypy
 
 
 .PHONY: test


### PR DESCRIPTION
We configure the files mypy should be run on in `.mypy.ini`, so no additional arguments should be passed.