### PR TITLE
Add name parameter to spawn

### DIFF
--- a/aiojobs/_job.py
+++ b/aiojobs/_job.py
@@ -57,7 +57,18 @@ class Job(Generic[_T]):
         return self._closed
 
     def get_name(self) -> str:
-        return self._task.get_name() if self._task else self._name
+        name = self._name
+        if sys.version_info >= (3, 8) and self._task:
+            name = self._task.get_name()
+        if name is None:
+            # Return generated default name
+            name = f"Job({self._coro})"
+        return name
+
+    def set_name(self, name):
+        if sys.version_info >= (3, 8):
+            return self._task.set_name(name)
+        self._name = name
 
     async def _do_wait(self, timeout: Optional[float]) -> _T:
         async with async_timeout.timeout(timeout):

--- a/aiojobs/_job.py
+++ b/aiojobs/_job.py
@@ -56,8 +56,7 @@ class Job(Generic[_T]):
     def closed(self) -> bool:
         return self._closed
 
-    @property
-    def name(self) -> str:
+    def get_name(self) -> str:
         return self._task.get_name() if self._task else self._name
 
     async def _do_wait(self, timeout: Optional[float]) -> _T:

--- a/aiojobs/_job.py
+++ b/aiojobs/_job.py
@@ -14,9 +14,15 @@ _T = TypeVar("_T", covariant=True)
 
 
 class Job(Generic[_T]):
-    def __init__(self, coro: Coroutine[object, object, _T], scheduler: Scheduler):
+    def __init__(
+        self,
+        coro: Coroutine[object, object, _T],
+        scheduler: Scheduler,
+        name: Optional[str] = None,
+    ):
         self._coro = coro
         self._scheduler: Optional[Scheduler] = scheduler
+        self._name: Optional[str] = name
         loop = asyncio.get_running_loop()
         self._started = loop.create_future()
 
@@ -49,6 +55,10 @@ class Job(Generic[_T]):
     @property
     def closed(self) -> bool:
         return self._closed
+
+    @property
+    def name(self) -> str:
+        return self._task.get_name() if self._task else self._name
 
     async def _do_wait(self, timeout: Optional[float]) -> _T:
         async with async_timeout.timeout(timeout):
@@ -118,7 +128,7 @@ class Job(Generic[_T]):
 
     def _start(self) -> None:
         assert self._task is None
-        self._task = asyncio.create_task(self._coro)
+        self._task = asyncio.create_task(self._coro, name=self._name)
         self._task.add_done_callback(self._done_callback)
         self._started.set_result(None)
 

--- a/aiojobs/_job.py
+++ b/aiojobs/_job.py
@@ -22,7 +22,7 @@ class Job(Generic[_T]):
     ):
         self._coro = coro
         self._scheduler: Optional[Scheduler] = scheduler
-        self._name: Optional[str] = name
+        self._name = name
         loop = asyncio.get_running_loop()
         self._started = loop.create_future()
 

--- a/aiojobs/_job.py
+++ b/aiojobs/_job.py
@@ -60,15 +60,13 @@ class Job(Generic[_T]):
         name = self._name
         if sys.version_info >= (3, 8) and self._task:
             name = self._task.get_name()
-        if name is None:
-            # Return generated default name
-            name = f"Job({self._coro})"
-        return name
+        return name or f"Job({self._coro})"
 
-    def set_name(self, name):
-        if sys.version_info >= (3, 8):
+    def set_name(self, name: str) -> None:
+        if sys.version_info >= (3, 8) and self._task is not None:
             return self._task.set_name(name)
-        self._name = name
+        else:
+            self._name = name
 
     async def _do_wait(self, timeout: Optional[float]) -> _T:
         async with async_timeout.timeout(timeout):

--- a/aiojobs/_job.py
+++ b/aiojobs/_job.py
@@ -56,11 +56,15 @@ class Job(Generic[_T]):
     def closed(self) -> bool:
         return self._closed
 
-    def get_name(self) -> str:
-        name = self._name
+    def get_name(self) -> Optional[str]:
+        """Get the task name.
+
+        See https://docs.python.org/3/library/asyncio-task.html#asyncio.Task.get_name.
+        Returns None if no name was set on the Job object and job has not yet started
+        """
         if sys.version_info >= (3, 8) and self._task:
-            name = self._task.get_name()
-        return name or f"Job({self._coro})"
+            return self._task.get_name()
+        return self._name
 
     def set_name(self, name: str) -> None:
         if sys.version_info >= (3, 8) and self._task is not None:

--- a/aiojobs/_job.py
+++ b/aiojobs/_job.py
@@ -127,7 +127,10 @@ class Job(Generic[_T]):
 
     def _start(self) -> None:
         assert self._task is None
-        self._task = asyncio.create_task(self._coro, name=self._name)
+        if sys.version_info >= (3, 8):
+            self._task = asyncio.create_task(self._coro, name=self._name)
+        else:
+            self._task = asyncio.create_task(self._coro)
         self._task.add_done_callback(self._done_callback)
         self._started.set_result(None)
 

--- a/aiojobs/_job.py
+++ b/aiojobs/_job.py
@@ -60,7 +60,7 @@ class Job(Generic[_T]):
         """Get the task name.
 
         See https://docs.python.org/3/library/asyncio-task.html#asyncio.Task.get_name.
-        Returns None if no name was set on the Job object and job has not yet started
+        Returns None if no name was set on the Job object and job has not yet started.
         """
         if sys.version_info >= (3, 8) and self._task:
             return self._task.get_name()

--- a/aiojobs/_job.py
+++ b/aiojobs/_job.py
@@ -67,10 +67,9 @@ class Job(Generic[_T]):
         return self._name
 
     def set_name(self, name: str) -> None:
+        self._name = name
         if sys.version_info >= (3, 8) and self._task is not None:
-            return self._task.set_name(name)
-        else:
-            self._name = name
+            self._task.set_name(name)
 
     async def _do_wait(self, timeout: Optional[float]) -> _T:
         async with async_timeout.timeout(timeout):

--- a/aiojobs/_scheduler.py
+++ b/aiojobs/_scheduler.py
@@ -85,10 +85,12 @@ class Scheduler(Collection[Job[object]]):
     def closed(self) -> bool:
         return self._closed
 
-    async def spawn(self, coro: Coroutine[object, object, _T]) -> Job[_T]:
+    async def spawn(
+        self, coro: Coroutine[object, object, _T], name: Optional[str] = None
+    ) -> Job[_T]:
         if self._closed:
             raise RuntimeError("Scheduling a new job after closing")
-        job = Job(coro, self)
+        job = Job(coro, self, name=name)
         should_start = self._limit is None or self.active_count < self._limit
         if should_start:
             job._start()

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -287,3 +287,11 @@ async def test_exception_handler_called_once(make_scheduler: _MakeScheduler) -> 
     await scheduler.spawn(coro())
     await scheduler.close()
     handler.assert_called_once()
+
+
+async def test_job_name_set(scheduler: Scheduler) -> None:
+    async def coro() -> None:
+        await asyncio.sleep(1)
+
+    job = await scheduler.spawn(coro(), name="test_job_name")
+    assert job.name == "test_job_name"

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -291,7 +291,8 @@ async def test_exception_handler_called_once(make_scheduler: _MakeScheduler) -> 
 
 async def test_job_name_set(scheduler: Scheduler) -> None:
     async def coro() -> None:
-        await asyncio.sleep(1)
+        """Dummy function."""
 
     job = await scheduler.spawn(coro(), name="test_job_name")
     assert job.name == "test_job_name"
+    assert job._task.get_name() == "test_job_name"

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -294,5 +294,5 @@ async def test_job_name_set(scheduler: Scheduler) -> None:
         """Dummy function."""
 
     job = await scheduler.spawn(coro(), name="test_job_name")
-    assert job.name == "test_job_name"
+    assert job.get_name() == "test_job_name"
     assert job._task.get_name() == "test_job_name"

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -303,9 +303,11 @@ async def test_get_job_name(scheduler: Scheduler) -> None:
     # check default name generation
     job2: Job[object] = await scheduler.spawn(coro())
     if sys.version_info >= (3, 8):
-        assert job2.get_name().startswith("Task-")
+        job_name = job2.get_name()
+        assert job_name is not None
+        assert job_name.startswith("Task-")
     else:
-        assert job2.get_name() == f"Job({job2._coro})"
+        assert job2.get_name() is None
 
 
 async def test_set_job_name(scheduler: Scheduler) -> None:

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -6,7 +6,6 @@ from unittest import mock
 
 import pytest
 
-from aiojobs._job import Job
 from aiojobs._scheduler import Scheduler
 
 _MakeScheduler = Callable[..., Awaitable[Scheduler]]

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -298,10 +298,14 @@ async def test_get_job_name(scheduler: Scheduler) -> None:
     job = await scheduler.spawn(coro(), name="test_job_name")
     assert job.get_name() == "test_job_name"
     if sys.version_info >= (3, 8):
+        assert job._task is not None
         assert job._task.get_name() == "test_job_name"
     # check default name generation
-    job2 = Job(coro, scheduler)
-    assert job2.get_name() == (f"Job({job2._coro})")
+    job2: Job[object] = await scheduler.spawn(coro())
+    if sys.version_info >= (3, 8):
+        assert job2.get_name().startswith("Task-")
+    else:
+        assert job2.get_name() == f"Job({job2._coro})"
 
 
 async def test_set_job_name(scheduler: Scheduler) -> None:
@@ -312,4 +316,5 @@ async def test_set_job_name(scheduler: Scheduler) -> None:
     job.set_name("changed_name")
     assert job.get_name() == "changed_name"
     if sys.version_info >= (3, 8):
+        assert job._task is not None
         assert job._task.get_name() == "changed_name"

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -300,14 +300,19 @@ async def test_get_job_name(scheduler: Scheduler) -> None:
     if sys.version_info >= (3, 8):
         assert job._task is not None
         assert job._task.get_name() == "test_job_name"
-    # check default name generation
-    job2: Job[object] = await scheduler.spawn(coro())
+
+
+async def test_get_default_job_name(scheduler: Scheduler) -> None:
+    async def coro() -> None:
+        """Dummy function."""
+
+    job = await scheduler.spawn(coro())
     if sys.version_info >= (3, 8):
-        job_name = job2.get_name()
+        job_name = job.get_name()
         assert job_name is not None
         assert job_name.startswith("Task-")
     else:
-        assert job2.get_name() is None
+        assert job.get_name() is None
 
 
 async def test_set_job_name(scheduler: Scheduler) -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

These changes add the ability to optionally set the underlying Task name parameter on Jobs. 

## Are there changes in behavior for the user?

Setting the Task name during spawn
```
await scheduler.spawn(my_task(), name="my-task")
await scheduler.spawn(another_task(), name="another-task")
# name is optional, so the following still works just fine
await scheduler.spawn(another_task())
```

Getting All Job Task names in  Scheduler
```
job_names = [job.name for job in scheduler]
```

## Related issue number

Fixes #324 

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
