### PR TITLE
Added graceful_timeout to wait for the end of tasks marked as cancelled.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -200,7 +200,7 @@ For using the project with *aiohttp* server a scheduler should be
 installed into app and new function should be used for spawning new
 jobs.
 
-.. function:: setup(app, **kwargs)
+.. function:: setup(app, graceful_timeout,  **kwargs)
 
    Register :attr:`aiohttp.web.Application.on_startup` and
    :attr:`aiohttp.web.Application.on_cleanup` hooks for creating
@@ -208,6 +208,8 @@ jobs.
    closing it on web server shutdown.
 
    * *app* - :class:`aiohttp.web.Application` instance.
+   * *graceful_timeout* - :class:`float` how many seconds should be wait
+     before the scheduler begin stopping.
    * *kwargs* - additional named parameters passed to :class:`aiojobs.Scheduler`.
 
 .. function:: spawn(request, coro)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -59,7 +59,7 @@ Integration with aiohttp.web
 
    app = web.Application()
    app.router.add_get('/', handler)
-   setup(app)
+   setup(app, graceful_timeout=60.0)
 
 or just
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

Added graceful_timeout to aiohttp setup function for wait when the tasks marked as cancelled are finished before shutting down the aiohttp server.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number
#72 Aiohttp: graceful shutdown doesn't wait for aiojob.asyncio.atomic handler to finish within canceled request.

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [X] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
