### PR TITLE
Only include aiojobs in packages in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ classifiers =
 
 [options]
 python_requires = >=3.7
-packages = find:
+packages = aiojobs
 include_package_data = True
 
 install_requires =


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Explicitly only include `aiojobs` in packages, ignoring other modules (such as the `tests` module from the repo, which is included today)

### Running build without the changes
```bash
❯ python -c "from setuptools import setup; setup()" build
running build
running build_py
creating build
creating build/lib
creating build/lib/tests
copying tests/__init__.py -> build/lib/tests
copying tests/conftest.py -> build/lib/tests
copying tests/test_job.py -> build/lib/tests
copying tests/test_scheduler.py -> build/lib/tests
copying tests/test_aiohttp.py -> build/lib/tests
creating build/lib/aiojobs
copying aiojobs/__init__.py -> build/lib/aiojobs
copying aiojobs/_job.py -> build/lib/aiojobs
copying aiojobs/aiohttp.py -> build/lib/aiojobs
copying aiojobs/_scheduler.py -> build/lib/aiojobs
running egg_info
writing aiojobs.egg-info/PKG-INFO
writing dependency_links to aiojobs.egg-info/dependency_links.txt
writing requirements to aiojobs.egg-info/requires.txt
writing top-level names to aiojobs.egg-info/top_level.txt
reading manifest file 'aiojobs.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
warning: no directories found matching 'examples'
warning: no previously-included files matching '*.pyc' found anywhere in distribution
no previously-included directories found matching 'docs/_build'
adding license file 'LICENSE'
writing manifest file 'aiojobs.egg-info/SOURCES.txt'
copying aiojobs/py.typed -> build/lib/aiojobs
warning: build_py: byte-compiling is disabled, skipping.
```
### Running build with the changes
```bash
❯ python -c "from setuptools import setup; setup()" build
running build
running build_py
creating build
creating build/lib
creating build/lib/aiojobs
copying aiojobs/__init__.py -> build/lib/aiojobs
copying aiojobs/_job.py -> build/lib/aiojobs
copying aiojobs/aiohttp.py -> build/lib/aiojobs
copying aiojobs/_scheduler.py -> build/lib/aiojobs
running egg_info
creating aiojobs.egg-info
writing aiojobs.egg-info/PKG-INFO
writing dependency_links to aiojobs.egg-info/dependency_links.txt
writing requirements to aiojobs.egg-info/requires.txt
writing top-level names to aiojobs.egg-info/top_level.txt
writing manifest file 'aiojobs.egg-info/SOURCES.txt'
reading manifest file 'aiojobs.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
warning: no directories found matching 'examples'
warning: no previously-included files matching '*.pyc' found anywhere in distribution
no previously-included directories found matching 'docs/_build'
adding license file 'LICENSE'
writing manifest file 'aiojobs.egg-info/SOURCES.txt'
copying aiojobs/py.typed -> build/lib/aiojobs
warning: build_py: byte-compiling is disabled, skipping.
```

## Are there changes in behavior for the user?

No, unless they were depending on the tests somehow being included.

## Related issue number

Fixes #407

## Checklist

Changes do not include any code changes, only an addition to the `setup.cfg` config file. 

*As for new fragment into the CHANGES folder, that seems out of date? There's only a towncrier managed CHANGES.rst file*

- [ ] ~I think the code is well written~
- [ ] ~Unit tests for the changes exist~
- [ ] ~Documentation reflects the changes~
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
