### PR TITLE
Use AppKey in aiohttp 3.9

### DIFF
--- a/aiojobs/aiohttp.py
+++ b/aiojobs/aiohttp.py
@@ -20,7 +20,8 @@ __all__ = ("setup", "spawn", "get_scheduler", "get_scheduler_from_app", "atomic"
 _T = TypeVar("_T")
 _RequestView = TypeVar("_RequestView", bound=Union[web.Request, web.View])
 
-# TODO(aiohttp 3.9+): Use AppKey
+
+AIOJOBS_SCHEDULER = web.AppKey("AIOJOBS_SCHEDULER", Scheduler)
 
 
 def get_scheduler(request: web.Request) -> Scheduler:
@@ -31,11 +32,11 @@ def get_scheduler(request: web.Request) -> Scheduler:
 
 
 def get_scheduler_from_app(app: web.Application) -> Optional[Scheduler]:
-    return app.get("AIOJOBS_SCHEDULER")
+    return app.get(AIOJOBS_SCHEDULER)
 
 
 def get_scheduler_from_request(request: web.Request) -> Optional[Scheduler]:
-    return request.config_dict.get("AIOJOBS_SCHEDULER")  # type: ignore[no-any-return]
+    return request.config_dict.get(AIOJOBS_SCHEDULER)
 
 
 async def spawn(request: web.Request, coro: Coroutine[object, object, _T]) -> Job[_T]:
@@ -62,7 +63,7 @@ def atomic(
 
 def setup(app: web.Application, **kwargs: Any) -> None:
     async def cleanup_context(app: web.Application) -> AsyncIterator[None]:
-        app["AIOJOBS_SCHEDULER"] = scheduler = Scheduler(**kwargs)
+        app[AIOJOBS_SCHEDULER] = scheduler = Scheduler(**kwargs)
         yield
         await scheduler.close()
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ install_requires =
 
 [options.extras_require]
 aiohttp =
-  aiohttp >= 3.8.0
+  aiohttp >= 3.9.0b1
 
 [flake8]
 ignore = N801,N802,N803,E203,E226,E305,W504,E252,E301,E302,E704,W503,W504,F811

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ install_requires =
 
 [options.extras_require]
 aiohttp =
-  aiohttp >= 3.9.0b1
+  aiohttp >= 3.9.0
 
 [flake8]
 ignore = N801,N802,N803,E203,E226,E305,W504,E252,E301,E302,E704,W503,W504,F811


### PR DESCRIPTION
I upgrade aiohttp to version 3.9, which requires changing the AppKey usage.

