### PR TITLE
Fix exceptions being suppressed

### DIFF
--- a/aiojobs/_scheduler.py
+++ b/aiojobs/_scheduler.py
@@ -179,7 +179,7 @@ class Scheduler(Collection[Job[object]]):
             async with asyncio_timeout(timeout):
                 while self._jobs or self._shields:
                     gather = asyncio.gather(
-                        *(job.wait() for job in self._jobs),
+                        *(job._wait() for job in self._jobs),
                         *self._shields,
                         return_exceptions=True,
                     )

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -639,7 +639,6 @@ async def test_wait_and_close_spawn(scheduler: Scheduler) -> None:
     assert another_spawned and another_done  # type: ignore[unreachable]
 
 
-@pytest.mark.xfail
 async def test_wait_and_close_exception(make_scheduler: _MakeScheduler) -> None:
     exc_handler = mock.Mock()
     scheduler = await make_scheduler(exception_handler=exc_handler)


### PR DESCRIPTION
The wait_and_close() code must not count as an explicit wait on the Job, otherwise exceptions will disappear.