### PR TITLE
add `__slots__` objects to Job object and Sheduler object

### DIFF
--- a/aiojobs/_job.py
+++ b/aiojobs/_job.py
@@ -18,6 +18,17 @@ _T = TypeVar("_T", covariant=True)
 
 
 class Job(Generic[_T]):
+    __slots__ = (
+        "_coro",
+        "_scheduler",
+        "_name",
+        "_started",
+        "_closed",
+        "_explicit",
+        "_task",
+        "_source_traceback",
+    )
+
     def __init__(
         self,
         coro: Coroutine[object, object, _T],

--- a/aiojobs/_scheduler.py
+++ b/aiojobs/_scheduler.py
@@ -30,6 +30,20 @@ ExceptionHandler = Callable[["Scheduler", Dict[str, Any]], None]
 
 
 class Scheduler(Collection[Job[object]]):
+
+    __slots__ = (
+        "_jobs",
+        "_shields",
+        "_close_timeout",
+        "_wait_timeout",
+        "_limit",
+        "_exception_handler",
+        "_failed_tasks",
+        "_failed_task",
+        "_pending",
+        "_closed",
+    )
+
     def __init__(
         self,
         *,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This pull request adds `__slots__` to `aiojobs.Job` and `aiojobs.Scheduler` to get rid of some smaller performance degredations around `__dict__` and adds more strictness to these objects.

## Are there changes in behavior for the user?

These Changes mainly involve internal refactoring and shouldn't affect users that are not internally tweaking or playing around with things involving these objects.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
