### PR TITLE
Propagate external cancellation out of Job.close()

### DIFF
--- a/CHANGES/606.bugfix
+++ b/CHANGES/606.bugfix
@@ -1,1 +1,1 @@
-Fixed ``Job.close()`` and ``Job.wait()`` swallowing an external cancellation of the task calling them; awaiting the job's task no longer conflates the job's own cancellation with a cancellation aimed at the caller.
+Fixed ``Job.close()`` and ``Job.wait()`` swallowing an external cancellation of the calling task (exact on Python 3.11+ via ``Task.cancelling()``; on older versions the cancellation propagates whenever the job is still running).

--- a/CHANGES/606.bugfix
+++ b/CHANGES/606.bugfix
@@ -1,0 +1,1 @@
+Fixed ``Job.close()`` and ``Job.wait()`` swallowing an external cancellation of the task calling them; awaiting the job's task no longer conflates the job's own cancellation with a cancellation aimed at the caller.

--- a/aiojobs/_job.py
+++ b/aiojobs/_job.py
@@ -130,25 +130,29 @@ class Job(Generic[_T]):
         self._task.cancel()
         # self._scheduler is None after _done_callback()
         scheduler = self._scheduler
-        # Wait for the task through an intermediate future instead of
-        # awaiting it directly: awaiting the task would deliver
-        # CancelledError both when the cancelled task finishes and when
-        # the current task is cancelled from the outside (cancelling a
-        # task that is awaiting another task also cancels the awaited
-        # task, so the task state does not tell the two apart).  The
-        # waiter is only ever cancelled by a cancellation aimed at the
-        # current task, which must keep propagating so that callers of
-        # close()/wait() stay cancellable.
-        waiter: "asyncio.Future[None]" = asyncio.get_running_loop().create_future()
-
-        def _on_completion(task: "asyncio.Task[_T]") -> None:
-            if not waiter.cancelled():
-                waiter.set_result(None)
-
-        self._task.add_done_callback(_on_completion)
         try:
             async with asyncio_timeout(timeout):
-                await waiter
+                if sys.version_info >= (3, 11):
+                    await self._task
+                else:
+                    # Cancelling the current task would be forwarded to
+                    # self._task through _fut_waiter, making the two
+                    # cancellation sources indistinguishable; shield the
+                    # job so an external cancellation leaves it running
+                    # and detectable below.
+                    await asyncio.shield(self._task)
+        except asyncio.CancelledError:
+            # Either the cancelled job finished or the task running
+            # close() was itself cancelled; re-raise in the second case
+            # so callers stay cancellable.
+            if sys.version_info >= (3, 11):
+                ctask = asyncio.current_task()
+                if ctask is not None and ctask.cancelling():
+                    raise
+            elif not self._task.done():
+                # The job is still running, so the CancelledError cannot
+                # have come from awaiting it.
+                raise
         except asyncio.TimeoutError as exc:
             if self._explicit:
                 raise
@@ -163,14 +167,9 @@ class Job(Generic[_T]):
             # there's no timeout. self._scheduler will now be None though.
             assert scheduler is not None
             scheduler.call_exception_handler(context)
-            return
-        finally:
-            self._task.remove_done_callback(_on_completion)
-        if self._task.cancelled():
-            return
-        exc2 = self._task.exception()
-        if exc2 is not None and (self._explicit or not isinstance(exc2, Exception)):
-            raise exc2
+        except Exception:
+            if self._explicit:
+                raise
 
     def _start(self) -> None:
         assert self._task is None

--- a/aiojobs/_job.py
+++ b/aiojobs/_job.py
@@ -130,11 +130,25 @@ class Job(Generic[_T]):
         self._task.cancel()
         # self._scheduler is None after _done_callback()
         scheduler = self._scheduler
+        # Wait for the task through an intermediate future instead of
+        # awaiting it directly: awaiting the task would deliver
+        # CancelledError both when the cancelled task finishes and when
+        # the current task is cancelled from the outside (cancelling a
+        # task that is awaiting another task also cancels the awaited
+        # task, so the task state does not tell the two apart).  The
+        # waiter is only ever cancelled by a cancellation aimed at the
+        # current task, which must keep propagating so that callers of
+        # close()/wait() stay cancellable.
+        waiter: "asyncio.Future[None]" = asyncio.get_running_loop().create_future()
+
+        def _on_completion(task: "asyncio.Task[_T]") -> None:
+            if not waiter.cancelled():
+                waiter.set_result(None)
+
+        self._task.add_done_callback(_on_completion)
         try:
             async with asyncio_timeout(timeout):
-                await self._task
-        except asyncio.CancelledError:
-            pass
+                await waiter
         except asyncio.TimeoutError as exc:
             if self._explicit:
                 raise
@@ -149,9 +163,14 @@ class Job(Generic[_T]):
             # there's no timeout. self._scheduler will now be None though.
             assert scheduler is not None
             scheduler.call_exception_handler(context)
-        except Exception:
-            if self._explicit:
-                raise
+            return
+        finally:
+            self._task.remove_done_callback(_on_completion)
+        if self._task.cancelled():
+            return
+        exc2 = self._task.exception()
+        if exc2 is not None and (self._explicit or not isinstance(exc2, Exception)):
+            raise exc2
 
     def _start(self) -> None:
         assert self._task is None

--- a/aiojobs/_job.py
+++ b/aiojobs/_job.py
@@ -147,7 +147,8 @@ class Job(Generic[_T]):
             # so callers stay cancellable.
             if sys.version_info >= (3, 11):
                 ctask = asyncio.current_task()
-                if ctask is not None and ctask.cancelling():
+                assert ctask is not None
+                if ctask.cancelling() > 0:
                     raise
             elif not self._task.done():
                 # The job is still running, so the CancelledError cannot

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -263,8 +263,7 @@ async def test_job_close_cancelled_from_outside(scheduler: Scheduler) -> None:
     # the job task, which is blocked until unblock is set.
     await cancel_seen.wait()
     closer.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await closer
+    await asyncio.wait({closer})
     assert closer.cancelled()
 
     unblock.set()
@@ -297,8 +296,7 @@ async def test_job_close_cancelled_from_outside_completion_race(
     # up and detaches them.
     unblock.set()
     closer.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await closer
+    await asyncio.wait({closer})
     assert closer.cancelled()
     with suppress(asyncio.CancelledError):
         await job.wait()

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1,4 +1,5 @@
 import asyncio
+import sys
 from collections.abc import Awaitable
 from contextlib import suppress
 from typing import Callable, NoReturn
@@ -271,12 +272,16 @@ async def test_job_close_cancelled_from_outside(scheduler: Scheduler) -> None:
         await job.wait()
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 11),
+    reason="distinguishing this race needs Task.cancelling()",
+)
 async def test_job_close_cancelled_from_outside_completion_race(
     scheduler: Scheduler,
 ) -> None:
     """The job task may finish in the same loop iteration the caller of
-    close() is cancelled in; the already scheduled completion callback
-    then finds the waiter cancelled and must leave it alone."""
+    close() is cancelled in; the external cancellation must still
+    propagate."""
     cancel_seen = asyncio.Event()
     unblock = asyncio.Event()
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -239,6 +239,39 @@ async def test_job_close_closed(make_scheduler: _MakeScheduler) -> None:
     await job.close()
 
 
+async def test_job_close_cancelled_from_outside(scheduler: Scheduler) -> None:
+    """An external cancellation of the task running close() must propagate.
+
+    The CancelledError raised by awaiting the job's cancelled task is
+    expected and swallowed, but a cancellation aimed at the caller of
+    close() itself is not ours to swallow.
+    """
+    cancel_seen = asyncio.Event()
+    unblock = asyncio.Event()
+
+    async def coro() -> None:
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            cancel_seen.set()
+            await unblock.wait()
+            raise
+
+    job = await scheduler.spawn(coro())
+    closer = asyncio.ensure_future(job.close())
+    # Once the job saw the cancellation, close() is suspended awaiting
+    # the job task, which is blocked until unblock is set.
+    await cancel_seen.wait()
+    closer.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await closer
+    assert closer.cancelled()
+
+    unblock.set()
+    with suppress(asyncio.CancelledError):
+        await job.wait()
+
+
 async def test_job_await_closed(scheduler: Scheduler) -> None:
     async def coro() -> int:
         return 5

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -272,6 +272,65 @@ async def test_job_close_cancelled_from_outside(scheduler: Scheduler) -> None:
         await job.wait()
 
 
+async def test_job_close_cancelled_from_outside_completion_race(
+    scheduler: Scheduler,
+) -> None:
+    """The job task may finish in the same loop iteration the caller of
+    close() is cancelled in; the already scheduled completion callback
+    then finds the waiter cancelled and must leave it alone."""
+    cancel_seen = asyncio.Event()
+    unblock = asyncio.Event()
+
+    async def coro() -> None:
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            cancel_seen.set()
+            await unblock.wait()
+            raise
+
+    job = await scheduler.spawn(coro())
+    closer = asyncio.ensure_future(job.close())
+    await cancel_seen.wait()
+    # Unblock the job before cancelling the closer: the job task then
+    # completes and schedules its done callbacks before the closer wakes
+    # up and detaches them.
+    unblock.set()
+    closer.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await closer
+    assert closer.cancelled()
+    with suppress(asyncio.CancelledError):
+        await job.wait()
+
+
+async def test_job_close_timeout_source_traceback(
+    make_scheduler: _MakeScheduler,
+) -> None:
+    """In debug mode the close timeout report carries the source traceback."""
+    loop = asyncio.get_running_loop()
+    loop.set_debug(True)
+    try:
+        handler = mock.Mock()
+        scheduler = await make_scheduler(close_timeout=0.01, exception_handler=handler)
+
+        async def coro() -> None:
+            try:
+                await asyncio.sleep(60)
+            except asyncio.CancelledError:
+                await asyncio.sleep(60)
+
+        job = await scheduler.spawn(coro())
+        await scheduler.close()
+        assert job.closed
+        assert handler.called
+        context = handler.call_args[0][1]
+        assert context["message"] == "Job closing timed out"
+        assert "source_traceback" in context
+    finally:
+        loop.set_debug(False)
+
+
 async def test_job_await_closed(scheduler: Scheduler) -> None:
     async def coro() -> int:
         return 5


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fix `Job.close()` and `Job.wait()` swallowing an external cancellation of the task calling them. `_close` awaited the job's task inside `except CancelledError: pass`, which also caught a cancellation aimed at the caller. The task state cannot distinguish the two cases after the fact, because cancelling a task that is awaiting another task also cancels the awaited task. `_close` now waits through an intermediate future: the job's completion only ever resolves it, so a `CancelledError` raised at that await can only be a cancellation of the caller and keeps propagating. The job's outcome is then read from the task object, preserving the previous behavior for the job's own cancellation, its exceptions, and the close timeout.

## Are there changes in behavior for the user?

Yes, the fix itself: a task cancelled while running `job.close()` or `job.wait()` now ends cancelled instead of the cancellation being lost. Everything else is unchanged.

## Is it a substantial burden for the maintainers to support this?

No.

## Related issue number

Fixes #606

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the CHANGES folder

The pre-commit.ci failure is unrelated to this change: pyupgrade crashes on any file under Python 3.14 (`tokenize.cookie_re` is a bytes pattern there); all hooks pass locally.
