### PR TITLE
Bump pyupgrade to v3.21.2 to fix pre-commit.ci on Python 3.14

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,7 +66,7 @@ repos:
   - id: detect-private-key
     exclude: ^examples/
 - repo: https://github.com/asottile/pyupgrade
-  rev: 'v3.19.1'
+  rev: 'v3.21.2'
   hooks:
   - id: pyupgrade
     args: ['--py38-plus']


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Bump the pyupgrade pre-commit hook from v3.19.1 to v3.21.2. The old version crashes under Python 3.14, where `tokenize.cookie_re` became a bytes pattern, whenever a file has a comment within its first lines (`docs/conf.py` triggers it here): `TypeError: cannot use a bytes pattern on a string-like object` in `_fix_tokens`. pre-commit.ci runs hooks under 3.14, so the `pre-commit.ci - pr` check currently fails on every PR in this repo (see #612 for an example). v3.21.2 vendors a str-based cookie regex and runs cleanly; the bump produces no file rewrites with the existing `--py38-plus` args.

This is deliberately rev-only; #604 proposes moving to `--py310-plus` with the corresponding code changes and can rebase on top.

## Are there changes in behavior for the user?

No. Lint tooling only.

## Is it a substantial burden for the maintainers to support this?

No.

## Related issue number

None.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist (N/A; config only, verified by running pre-commit on all files and reproducing the crash/fix under 3.14)
- [x] Documentation reflects the changes (N/A)
- [x] Add a new news fragment into the CHANGES folder (N/A; tooling bump, same class as dependabot updates which carry no fragment)
